### PR TITLE
Fix cleanup regexes to handle upercase lowercase r in file extension

### DIFF
--- a/R/testthat_roclet.R
+++ b/R/testthat_roclet.R
@@ -76,7 +76,7 @@ roclet_clean.roclet_testthat <- function(x, base_path) {
   verify_testthat_used()
   
   testfiles <- dir(path = file.path(base_path, "tests", "testthat"), 
-                   pattern = "^test-roxytest-.*\\.R$", 
+                   pattern = "^test-roxytest-.*\\.[Rr]$", 
                    full.names = TRUE)
   
   # Has side-effects: deletes files on disk

--- a/R/tinytest_roclet.R
+++ b/R/tinytest_roclet.R
@@ -76,7 +76,7 @@ roclet_clean.roclet_tinytest <- function(x, base_path) {
   verify_tinytest_used()
   
   testfiles <- dir(path = file.path(base_path, "inst", "tinytest"), 
-                   pattern = "^test-roxytest-.*\\.R$", 
+                   pattern = "^test-roxytest-.*\\.[Rr]$", 
                    full.names = TRUE)
   
   # Has side-effects: deletes files on disk


### PR DESCRIPTION
This PR fixes https://github.com/mikldk/roxytest/issues/21 by changing the regex used by roxytests cleanup functions to be case insensitive with respect to the ".r" file extension.